### PR TITLE
React Native 0.61 update with ugly kludge

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,12 +38,10 @@ const REACT_NATIVE_PREFIX = 'react-native-'
 
 const EXAMPLE_APP_JS_FILENAME = 'App.js'
 
-// quick workaround solution for symlinked modules ref:
-// https://github.com/brodybits/create-react-native-module/issues/232
+// metro.config.js overwrite with workarounds
 const EXAMPLE_METRO_CONFIG_FILENAME = 'metro.config.js'
 const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
-// quick workaround solution for symlinked modules ref:
-// https://github.com/brodybits/create-react-native-module/issues/232
+// with workarounds
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -59,6 +57,8 @@ module.exports = {
     }
   },
 
+  // quick workaround solution for symlinked modules ref:
+  // https://github.com/brodybits/create-react-native-module/issues/232
   watchFolders: ['.', '..']
 }`
 
@@ -214,7 +214,11 @@ Promise.resolve().then(async () => {
 
   console.log(
     INFO,
-    'It is possible to generate an example test app, using React Native 0.61.'
+    'It is possible to generate an example test app, using React Native 0.61,'
+  )
+  console.log(
+    INFO,
+    'with workarounds in metro.config.js overwrite for metro linking issues'
   )
   console.log(
     INFO,
@@ -306,13 +310,10 @@ Promise.resolve().then(async () => {
       exampleAppTemplate.content(createOptions)
     )
 
-    // quick workaround solution for symlinked modules ref:
-    // https://github.com/brodybits/create-react-native-module/issues/232
-    console.log(INFO, `overwrite ${EXAMPLE_METRO_CONFIG_FILENAME}`)
-    console.log(INFO, 'quick workaround solution for symlinked modules')
+    // metro.config.js overwrite with workarounds
     console.log(
       INFO,
-      'ref: https://github.com/brodybits/create-react-native-module/issues/232'
+      `overwrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workarounds`
     )
     await fs.outputFile(
       path.join(

--- a/main.js
+++ b/main.js
@@ -45,6 +45,20 @@ const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
 // quick workaround solution for symlinked modules ref:
 // https://github.com/brodybits/create-react-native-module/issues/232
 module.exports = {
+  // ugly kludge as workaround for an issue encountered starting with
+  // metro 0.55 / React Native 0.61
+  // (was not needed with React Native 0.60 / metro 0.54)
+  resolver: {
+    get extraNodeModules () {
+      return Object.assign(
+        {},
+        ...Object.keys(require('./package.json').dependencies).map(name => ({
+          [name]: ['.', 'node_modules', name].join('/'),
+        }))
+      )
+    }
+  },
+
   watchFolders: ['.', '..']
 }`
 

--- a/main.js
+++ b/main.js
@@ -200,11 +200,7 @@ Promise.resolve().then(async () => {
 
   console.log(
     INFO,
-    'It is possible to generate an example test app, using React Native 0.60.'
-  )
-  console.log(
-    INFO,
-    '(There is currently a problem with linking on React Native 0.61.)'
+    'It is possible to generate an example test app, using React Native 0.61.'
   )
   console.log(
     INFO,
@@ -214,7 +210,7 @@ Promise.resolve().then(async () => {
   const { generateExampleApp } = await prompt({
     type: 'confirm',
     name: 'generateExampleApp',
-    message: 'Generate the example app (with React Native 0.60)?',
+    message: 'Generate the example app (with React Native 0.61)?',
     initial: true
   })
 
@@ -271,8 +267,8 @@ Promise.resolve().then(async () => {
 
     const exampleAppName = 'example'
 
-    // example app with React Native 0.60 for now
-    const generateExampleAppOptions = ['--version', 'react-native@0.60']
+    // example app with React Native 0.61 (for now)
+    const generateExampleAppOptions = ['--version', 'react-native@0.61']
 
     await execa(
       'react-native',

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -320,6 +320,20 @@ const styles = StyleSheet.create({
 // quick workaround solution for symlinked modules ref:
 // https://github.com/brodybits/create-react-native-module/issues/232
 module.exports = {
+  // ugly kludge as workaround for an issue encountered starting with
+  // metro 0.55 / React Native 0.61
+  // (was not needed with React Native 0.60 / metro 0.54)
+  resolver: {
+    get extraNodeModules () {
+      return Object.assign(
+        {},
+        ...Object.keys(require('./package.json').dependencies).map(name => ({
+          [name]: ['.', 'node_modules', name].join('/'),
+        }))
+      )
+    }
+  },
+
   watchFolders: ['.', '..']
 }",
     },

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -187,7 +187,7 @@ Array [
       "args": Array [
         Object {
           "initial": true,
-          "message": "Generate the example app (with React Native 0.60)?",
+          "message": "Generate the example app (with React Native 0.61)?",
           "name": "generateExampleApp",
           "onState": [Function],
           "type": "confirm",
@@ -246,7 +246,7 @@ Array [
         "init",
         "example",
         "--version",
-        "react-native@0.60",
+        "react-native@0.61",
       ],
     ],
   },

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -317,8 +317,7 @@ const styles = StyleSheet.create({
     "outputFile": Object {
       "filePath": "$CWD/react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
-// quick workaround solution for symlinked modules ref:
-// https://github.com/brodybits/create-react-native-module/issues/232
+// with workarounds
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -334,6 +333,8 @@ module.exports = {
     }
   },
 
+  // quick workaround solution for symlinked modules ref:
+  // https://github.com/brodybits/create-react-native-module/issues/232
   watchFolders: ['.', '..']
 }",
     },


### PR DESCRIPTION
This ugly kludge workaround resolves an issue that I encountered with symlink to `..` starting with metro 0.55 / React Native 0.61 (was not needed with React Native 0.60 / metro 0.54):

```js
  resolver: {
    get extraNodeModules () {
      return Object.assign(
        {},
        ...Object.keys(require('./package.json').dependencies).map(name => ({
          [name]: ['.', 'node_modules', name].join('/'),
        }))
      )
    }
  }
```

Without this ugly kludge, I encountered this error message in the generated example with the symlink on React Native 0.61:

```
error: bundling failed: Error: Unable to resolve module `react-native` from `../index.js`: react-native could not be found within the project.
```

I hope the issue can be resolved on metro within the near future.