### PR TITLE
flexible react native version for example app

### DIFF
--- a/main.js
+++ b/main.js
@@ -215,7 +215,7 @@ Promise.resolve().then(async () => {
   console.log(INFO, 'It is possible to generate an example test app,')
   console.log(
     INFO,
-    'with workarounds in metro.config.js overwrite for metro linking issues'
+    'with workarounds in metro.config.js for metro linking issues'
   )
   console.log(
     INFO,
@@ -225,7 +225,7 @@ Promise.resolve().then(async () => {
   const { generateExampleApp } = await prompt({
     type: 'confirm',
     name: 'generateExampleApp',
-    message: 'Generate the example app?',
+    message: 'Generate the example app (with workarounds in metro.config.js)?',
     initial: true
   })
 
@@ -234,7 +234,7 @@ Promise.resolve().then(async () => {
         type: 'text',
         name: 'reactNativeVersion',
         message:
-          'What react-native version to use for the example app (should be at least 0.60)?',
+          'What react-native version to use for the example app (should be at least react-native@0.60)?',
         initial: 'react-native@latest'
       })
     : null

--- a/main.js
+++ b/main.js
@@ -212,10 +212,7 @@ Promise.resolve().then(async () => {
     initial: 'MIT'
   })
 
-  console.log(
-    INFO,
-    'It is possible to generate an example test app, using React Native 0.61,'
-  )
+  console.log(INFO, 'It is possible to generate an example test app,')
   console.log(
     INFO,
     'with workarounds in metro.config.js overwrite for metro linking issues'
@@ -228,9 +225,19 @@ Promise.resolve().then(async () => {
   const { generateExampleApp } = await prompt({
     type: 'confirm',
     name: 'generateExampleApp',
-    message: 'Generate the example app (with React Native 0.61)?',
+    message: 'Generate the example app?',
     initial: true
   })
+
+  const { reactNativeVersion } = generateExampleApp
+    ? await prompt({
+        type: 'text',
+        name: 'reactNativeVersion',
+        message:
+          'What react-native version to use for the example app (should be at least 0.60)?',
+        initial: 'react-native@latest'
+      })
+    : null
 
   const { showReactNativeOutput } = generateExampleApp
     ? await prompt({
@@ -285,8 +292,7 @@ Promise.resolve().then(async () => {
 
     const exampleAppName = 'example'
 
-    // example app with React Native 0.61 (for now)
-    const generateExampleAppOptions = ['--version', 'react-native@0.61']
+    const generateExampleAppOptions = ['--version', reactNativeVersion]
 
     await execa(
       'react-native',

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -187,10 +187,23 @@ Array [
       "args": Array [
         Object {
           "initial": true,
-          "message": "Generate the example app (with React Native 0.61)?",
+          "message": "Generate the example app?",
           "name": "generateExampleApp",
           "onState": [Function],
           "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native@latest",
+          "message": "What react-native version to use for the example app (should be at least 0.60)?",
+          "name": "reactNativeVersion",
+          "onState": [Function],
+          "type": "text",
         },
       ],
     },
@@ -246,7 +259,7 @@ Array [
         "init",
         "example",
         "--version",
-        "react-native@0.61",
+        "react-native@latest",
       ],
     ],
   },

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -187,7 +187,7 @@ Array [
       "args": Array [
         Object {
           "initial": true,
-          "message": "Generate the example app?",
+          "message": "Generate the example app (with workarounds in metro.config.js)?",
           "name": "generateExampleApp",
           "onState": [Function],
           "type": "confirm",
@@ -200,7 +200,7 @@ Array [
       "args": Array [
         Object {
           "initial": "react-native@latest",
-          "message": "What react-native version to use for the example app (should be at least 0.60)?",
+          "message": "What react-native version to use for the example app (should be at least react-native@0.60)?",
           "name": "reactNativeVersion",
           "onState": [Function],
           "type": "text",

--- a/tests/init-with-example/init-with-example.test.js
+++ b/tests/init-with-example/init-with-example.test.js
@@ -14,6 +14,7 @@ mockPromptResponses = {
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: true },
+  reactNativeVersion: { reactNativeVersion: 'react-native@latest' },
   showReactNativeOutput: { showReactNativeOutput: true }
 }
 


### PR DESCRIPTION
tested as follows:

✅ `npm test`
✅ able to create library module with example on default version of React Native (`react-native@latest`, is now React Native 0.61) and run the example on Android & iOS
✅ able to create library module with example on `react-native@next` (which is now React Native 0.62-RC) and run the example on Android & iOS
✅ able to create view with example on `react-native@next` (which is now React Native 0.62-RC) and run the example on Android & iOS