### PR TITLE
[TBD] cleanup metro post 0.54 workaround kludge - alternative solution

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,9 @@ const EXAMPLE_APP_JS_FILENAME = 'App.js'
 const EXAMPLE_METRO_CONFIG_FILENAME = 'metro.config.js'
 const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
 // with workarounds
+
+const path = require('path')
+
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -51,7 +54,7 @@ module.exports = {
       return Object.assign(
         {},
         ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: ['.', 'node_modules', name].join('/'),
+          [name]: path.join('.', 'node_modules', name)
         }))
       )
     }

--- a/main.js
+++ b/main.js
@@ -51,11 +51,12 @@ module.exports = {
   // (was not needed with React Native 0.60 / metro 0.54)
   resolver: {
     get extraNodeModules () {
-      return Object.assign(
-        {},
-        ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: path.join('.', 'node_modules', name)
-        }))
+      const { dependencies } = require('./package.json')
+      return Object.fromEntries(
+        Object.keys(dependencies).map(name => [
+          name,
+          path.join('.', 'node_modules', name)
+        ])
       )
     }
   },

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -331,6 +331,9 @@ const styles = StyleSheet.create({
       "filePath": "$CWD/react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workarounds
+
+const path = require('path')
+
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -340,7 +343,7 @@ module.exports = {
       return Object.assign(
         {},
         ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: ['.', 'node_modules', name].join('/'),
+          [name]: path.join('.', 'node_modules', name)
         }))
       )
     }

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -340,11 +340,12 @@ module.exports = {
   // (was not needed with React Native 0.60 / metro 0.54)
   resolver: {
     get extraNodeModules () {
-      return Object.assign(
-        {},
-        ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: path.join('.', 'node_modules', name)
-        }))
+      const { dependencies } = require('./package.json')
+      return Object.fromEntries(
+        Object.keys(dependencies).map(name => [
+          name,
+          path.join('.', 'node_modules', name)
+        ])
       )
     }
   },


### PR DESCRIPTION
_cleanup for workaround kludge that was introduced in PR #2_

- use path.join instead of [...].join('/')
- use `Object.fromEntries` instead of the messy Object.assign([], Object.keys(...).map(...) expression that I had made

ideas from <https://github.com/facebook/metro/issues/1>, as discussed in #4

Note that this proposal will likely be rejected (by myself) in favor of using a proxy object, as suggested in <https://github.com/facebook/metro/issues/1#issuecomment-541642857>.

An interesting point is that JavaScript tuple-like arrays as returned by Object.entries() and used in `Object.fromEntries` can sometimes work just as well as JavaScript objects, in a less convoluted manner. This could help me with some JavaScript SQLite API ideas.