### PR TITLE
improve workaround for issue with metro post-0.54

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,18 +46,14 @@ const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
 const path = require('path')
 
 module.exports = {
-  // ugly kludge as workaround for an issue encountered starting with
+  // workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
   // (was not needed with React Native 0.60 / metro 0.54)
   resolver: {
-    get extraNodeModules () {
-      return Object.assign(
-        {},
-        ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: path.join('.', 'node_modules', name)
-        }))
-      )
-    }
+    extraNodeModules: new Proxy(
+      {},
+      { get: (_, name) => path.join('.', 'node_modules', name) }
+    )
   },
 
   // quick workaround solution for symlinked modules ref:

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ const REACT_NATIVE_PREFIX = 'react-native-'
 
 const EXAMPLE_APP_JS_FILENAME = 'App.js'
 
-// metro.config.js overwrite with workaround solutions
+// rewrite metro.config.js with workaround solutions
 const EXAMPLE_METRO_CONFIG_FILENAME = 'metro.config.js'
 const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
 // with workaround solutions
@@ -315,7 +315,7 @@ Promise.resolve().then(async () => {
       exampleAppTemplate.content(createOptions)
     )
 
-    // rewrite metro.config.js overwrite with workaround solutions
+    // rewrite metro.config.js with workaround solutions
     console.log(
       INFO,
       `rewrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workaround solutions`

--- a/main.js
+++ b/main.js
@@ -38,17 +38,17 @@ const REACT_NATIVE_PREFIX = 'react-native-'
 
 const EXAMPLE_APP_JS_FILENAME = 'App.js'
 
-// metro.config.js overwrite with workarounds
+// metro.config.js overwrite with workaround solutions
 const EXAMPLE_METRO_CONFIG_FILENAME = 'metro.config.js'
 const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
-// with workarounds
+// with workaround solutions
 
 const path = require('path')
 
 module.exports = {
-  // workaround for an issue encountered starting with
-  // metro 0.55 / React Native 0.61
-  // (was not needed with React Native 0.60 / metro 0.54)
+  // workaround for issue with symlinks encountered starting with
+  // metro@0.55 / React Native 0.61
+  // (not needed with React Native 0.60 / metro@0.54)
   resolver: {
     extraNodeModules: new Proxy(
       {},
@@ -56,7 +56,7 @@ module.exports = {
     )
   },
 
-  // quick workaround solution for symlinked modules ref:
+  // quick workaround solution for issue with symlinked modules ref:
   // https://github.com/brodybits/create-react-native-module/issues/232
   watchFolders: ['.', '..']
 }`
@@ -315,10 +315,10 @@ Promise.resolve().then(async () => {
       exampleAppTemplate.content(createOptions)
     )
 
-    // metro.config.js overwrite with workarounds
+    // rewrite metro.config.js overwrite with workaround solutions
     console.log(
       INFO,
-      `overwrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workarounds`
+      `rewrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workaround solutions`
     )
     await fs.outputFile(
       path.join(

--- a/main.js
+++ b/main.js
@@ -42,6 +42,9 @@ const EXAMPLE_APP_JS_FILENAME = 'App.js'
 const EXAMPLE_METRO_CONFIG_FILENAME = 'metro.config.js'
 const EXAMPLE_METRO_CONFIG_WORKAROUND = `// metro.config.js
 // with workarounds
+
+const path = require('path')
+
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -51,7 +54,7 @@ module.exports = {
       return Object.assign(
         {},
         ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: ['.', 'node_modules', name].join('/'),
+          [name]: path.join('.', 'node_modules', name)
         }))
       )
     }

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -330,14 +330,14 @@ const styles = StyleSheet.create({
     "outputFile": Object {
       "filePath": "$CWD/react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
-// with workarounds
+// with workaround solutions
 
 const path = require('path')
 
 module.exports = {
-  // workaround for an issue encountered starting with
-  // metro 0.55 / React Native 0.61
-  // (was not needed with React Native 0.60 / metro 0.54)
+  // workaround for issue with symlinks encountered starting with
+  // metro@0.55 / React Native 0.61
+  // (not needed with React Native 0.60 / metro@0.54)
   resolver: {
     extraNodeModules: new Proxy(
       {},
@@ -345,7 +345,7 @@ module.exports = {
     )
   },
 
-  // quick workaround solution for symlinked modules ref:
+  // quick workaround solution for issue with symlinked modules ref:
   // https://github.com/brodybits/create-react-native-module/issues/232
   watchFolders: ['.', '..']
 }",

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -331,6 +331,9 @@ const styles = StyleSheet.create({
       "filePath": "$CWD/react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workarounds
+
+const path = require('path')
+
 module.exports = {
   // ugly kludge as workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
@@ -340,7 +343,7 @@ module.exports = {
       return Object.assign(
         {},
         ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: ['.', 'node_modules', name].join('/'),
+          [name]: path.join('.', 'node_modules', name)
         }))
       )
     }

--- a/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example.test.js.snap
@@ -335,18 +335,14 @@ const styles = StyleSheet.create({
 const path = require('path')
 
 module.exports = {
-  // ugly kludge as workaround for an issue encountered starting with
+  // workaround for an issue encountered starting with
   // metro 0.55 / React Native 0.61
   // (was not needed with React Native 0.60 / metro 0.54)
   resolver: {
-    get extraNodeModules () {
-      return Object.assign(
-        {},
-        ...Object.keys(require('./package.json').dependencies).map(name => ({
-          [name]: path.join('.', 'node_modules', name)
-        }))
-      )
-    }
+    extraNodeModules: new Proxy(
+      {},
+      { get: (_, name) => path.join('.', 'node_modules', name) }
+    )
   },
 
   // quick workaround solution for symlinked modules ref:


### PR DESCRIPTION
improve the workaround solution that was introduced in PR #2, as suggested in <https://github.com/facebook/metro/issues/1#issuecomment-541642857>:

- use path.join instead of [...].join('/')
- use JavaScript Proxy object for exported `resolver.extraNodeModules`
  (hopefully more dynamic)

Verified that:

- ✅ `npm test` passes
- ✅ able to generate library module with example on React Native 0.60 and run the example on Android & iOS
- ✅ able to generate library module with example on react-native@latest (0.61) and run the example on Android & iOS
- ✅ able to generate view with example on react-native@latest (0.61) and run the example on Android & iOS
- ✅ able to generate library module with example on react-native@next (0.62 RC) and run the example on Android & iOS
- ✅ able to generate view with example on react-native@next (0.62 RC) and run the example on Android & iOS

resolves #4