### PR TITLE
testing: include execa options in test snapshots

### DIFF
--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -139,6 +139,7 @@ Array [
         "config",
         "user.name",
       ],
+      undefined,
     ],
   },
   Object {
@@ -148,6 +149,7 @@ Array [
         "config",
         "user.email",
       ],
+      undefined,
     ],
   },
   Object {
@@ -271,6 +273,7 @@ Array [
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -291,6 +294,7 @@ Array [
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -341,6 +345,11 @@ Array [
         "--version",
         "react-native@latest",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-module",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {
@@ -463,6 +472,11 @@ module.exports = {
         "add",
         "link:../",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-module/example",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {
@@ -483,6 +497,7 @@ module.exports = {
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -503,6 +518,11 @@ module.exports = {
       Array [
         "install",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-module/example/ios",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -32,8 +32,8 @@ jest.mock('prompts', () => args => {
   return Promise.resolve(mockPromptResponses[optionsArray[0].name])
 })
 
-jest.mock('execa', () => (cmd, args) => {
-  mockCallSnapshot.push({ execa: [cmd, args] })
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
     if (args[1] == 'user.email')
       return Promise.resolve({ stdout: 'alice@example.com' })

--- a/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
@@ -139,6 +139,7 @@ Array [
         "config",
         "user.name",
       ],
+      undefined,
     ],
   },
   Object {
@@ -148,6 +149,7 @@ Array [
         "config",
         "user.email",
       ],
+      undefined,
     ],
   },
   Object {

--- a/tests/no-example/no-example-with-log.test.js
+++ b/tests/no-example/no-example-with-log.test.js
@@ -29,8 +29,8 @@ jest.mock('prompts', () => args => {
   return Promise.resolve(mockPromptResponses[optionsArray[0].name])
 })
 
-jest.mock('execa', () => (cmd, args) => {
-  mockCallSnapshot.push({ execa: [cmd, args] })
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
     if (args[1] == 'user.email')
       return Promise.resolve({ stdout: 'alice@example.com' })

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -152,6 +152,7 @@ Array [
         "config",
         "user.name",
       ],
+      undefined,
     ],
   },
   Object {
@@ -161,6 +162,7 @@ Array [
         "config",
         "user.email",
       ],
+      undefined,
     ],
   },
   Object {

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -29,8 +29,8 @@ jest.mock('prompts', () => args => {
   return Promise.resolve(mockPromptResponses[optionsArray[0].name])
 })
 
-jest.mock('execa', () => (cmd, args) => {
-  mockCallSnapshot.push({ execa: [cmd, args] })
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
     if (args[1] == 'user.email')
       return Promise.resolve({ stdout: 'alice@example.com' })

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -152,6 +152,7 @@ Array [
         "config",
         "user.name",
       ],
+      undefined,
     ],
   },
   Object {
@@ -161,6 +162,7 @@ Array [
         "config",
         "user.email",
       ],
+      undefined,
     ],
   },
   Object {
@@ -284,6 +286,7 @@ Array [
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -304,6 +307,7 @@ Array [
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -354,6 +358,11 @@ Array [
         "--version",
         "react-native@latest",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-view",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {
@@ -464,6 +473,11 @@ module.exports = {
         "add",
         "link:../",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-view/example",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {
@@ -484,6 +498,7 @@ module.exports = {
       Array [
         "--version",
       ],
+      undefined,
     ],
   },
   Object {
@@ -504,6 +519,11 @@ module.exports = {
       Array [
         "install",
       ],
+      Object {
+        "cwd": "$CWD/react-native-test-view/example/ios",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
     ],
   },
   Object {

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -32,8 +32,8 @@ jest.mock('prompts', () => args => {
   return Promise.resolve(mockPromptResponses[optionsArray[0].name])
 })
 
-jest.mock('execa', () => (cmd, args) => {
-  mockCallSnapshot.push({ execa: [cmd, args] })
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
     if (args[1] == 'user.email')
       return Promise.resolve({ stdout: 'alice@example.com' })


### PR DESCRIPTION
✅ `npm test` ok

NOTE: The **bug** label is used since this is something that should have been included in the very beginning.