### PR TITLE
use path.resolve() to resolve subdirectory paths

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,8 +64,9 @@ module.exports = {
 }
 `
 
-// path helper abstracted out:
+// path helpers abstracted out:
 const resolveSubpath = (...paths) => path.resolve('.', ...paths)
+const joinPath = path.join
 
 // quick workaround ref:
 // https://github.com/terkelg/prompts/issues/252
@@ -400,7 +401,7 @@ Promise.resolve().then(async () => {
 
     // to show the subdirectory path of the example app
     // (both relative & absolute):
-    const exampleAppSubdirectory = path.join(modulePackageName, exampleAppName)
+    const exampleAppSubdirectory = joinPath(modulePackageName, exampleAppName)
     const exampleAppPath = resolveSubpath(modulePackageName, exampleAppName)
     // show the example app info:
     log(BULB, `check out the example app in ${exampleAppSubdirectory}`)

--- a/main.js
+++ b/main.js
@@ -67,6 +67,9 @@ module.exports = {
 // path helpers abstracted out:
 const resolveSubpath = (...paths) => path.resolve('.', ...paths)
 const joinPath = path.join
+// abstract out reamining use of `process.cwd()` & `path.join()`
+const composeSubdirectoryPath = (...args) => path.join(...args)
+const COMPOSE_SUBDIRECTORY_PATH_BASE = process.cwd()
 
 // quick workaround ref:
 // https://github.com/terkelg/prompts/issues/252
@@ -311,7 +314,10 @@ Promise.resolve().then(async () => {
       'react-native',
       ['init', exampleAppName].concat(generateExampleAppOptions),
       {
-        cwd: path.join(process.cwd(), modulePackageName),
+        cwd: composeSubdirectoryPath(
+          COMPOSE_SUBDIRECTORY_PATH_BASE,
+          modulePackageName
+        ),
         stdout: showReactNativeOutput ? 'inherit' : null,
         stderr: showReactNativeOutput ? 'inherit' : null
       }
@@ -320,8 +326,8 @@ Promise.resolve().then(async () => {
     log(INFO, 'generating App.js in the example app')
 
     await fs.outputFile(
-      path.join(
-        process.cwd(),
+      composeSubdirectoryPath(
+        COMPOSE_SUBDIRECTORY_PATH_BASE,
         modulePackageName,
         exampleAppName,
         EXAMPLE_APP_JS_FILENAME
@@ -335,8 +341,8 @@ Promise.resolve().then(async () => {
       `rewrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workaround solutions`
     )
     await fs.outputFile(
-      path.join(
-        process.cwd(),
+      composeSubdirectoryPath(
+        COMPOSE_SUBDIRECTORY_PATH_BASE,
         modulePackageName,
         exampleAppName,
         EXAMPLE_METRO_CONFIG_FILENAME
@@ -352,7 +358,11 @@ Promise.resolve().then(async () => {
     )
 
     await execa('yarn', ['add', 'link:../'], {
-      cwd: path.join(process.cwd(), modulePackageName, exampleAppName),
+      cwd: composeSubdirectoryPath(
+        COMPOSE_SUBDIRECTORY_PATH_BASE,
+        modulePackageName,
+        exampleAppName
+      ),
       stdout: showReactNativeOutput ? 'inherit' : null,
       stderr: showReactNativeOutput ? 'inherit' : null
     })
@@ -383,8 +393,8 @@ Promise.resolve().then(async () => {
 
       try {
         await execa('pod', ['install'], {
-          cwd: path.join(
-            process.cwd(),
+          cwd: composeSubdirectoryPath(
+            COMPOSE_SUBDIRECTORY_PATH_BASE,
             modulePackageName,
             exampleAppName,
             'ios'

--- a/main.js
+++ b/main.js
@@ -67,9 +67,8 @@ module.exports = {
 // path helpers abstracted out:
 const resolveSubpath = (...paths) => path.resolve('.', ...paths)
 const joinPath = path.join
-// abstract out reamining use of `process.cwd()` & `path.join()`
-const composeSubdirectoryPath = (...args) => path.join(...args)
-const COMPOSE_SUBDIRECTORY_PATH_BASE = process.cwd()
+const composeSubdirectoryPath = path.resolve
+const COMPOSE_SUBDIRECTORY_PATH_BASE = '.'
 
 // quick workaround ref:
 // https://github.com/terkelg/prompts/issues/252

--- a/main.js
+++ b/main.js
@@ -64,6 +64,9 @@ module.exports = {
 }
 `
 
+// path helper abstracted out:
+const resolveSubpath = (...paths) => path.resolve('.', ...paths)
+
 // quick workaround ref:
 // https://github.com/terkelg/prompts/issues/252
 const onState = ({ aborted }) => {
@@ -395,10 +398,13 @@ Promise.resolve().then(async () => {
       log(OK, 'additional pod install ok')
     }
 
-    // to show the subdirectory path of the example app:
+    // to show the subdirectory path of the example app
+    // (both relative & absolute):
     const exampleAppSubdirectory = path.join(modulePackageName, exampleAppName)
+    const exampleAppPath = resolveSubpath(modulePackageName, exampleAppName)
     // show the example app info:
     log(BULB, `check out the example app in ${exampleAppSubdirectory}`)
+    log(INFO, `(${exampleAppPath})`)
     log(BULB, 'recommended: run Metro Bundler in a new shell')
     log(INFO, `(cd ${exampleAppSubdirectory} && yarn start)`)
     log(BULB, 'enter the following commands to run the example app:')

--- a/main.js
+++ b/main.js
@@ -64,11 +64,9 @@ module.exports = {
 }
 `
 
-// path helpers abstracted out:
+// path helpers:
 const resolveSubpath = (...paths) => path.resolve('.', ...paths)
 const joinPath = path.join
-const composeSubdirectoryPath = path.resolve
-const COMPOSE_SUBDIRECTORY_PATH_BASE = '.'
 
 // quick workaround ref:
 // https://github.com/terkelg/prompts/issues/252
@@ -313,10 +311,7 @@ Promise.resolve().then(async () => {
       'react-native',
       ['init', exampleAppName].concat(generateExampleAppOptions),
       {
-        cwd: composeSubdirectoryPath(
-          COMPOSE_SUBDIRECTORY_PATH_BASE,
-          modulePackageName
-        ),
+        cwd: resolveSubpath(modulePackageName),
         stdout: showReactNativeOutput ? 'inherit' : null,
         stderr: showReactNativeOutput ? 'inherit' : null
       }
@@ -325,8 +320,7 @@ Promise.resolve().then(async () => {
     log(INFO, 'generating App.js in the example app')
 
     await fs.outputFile(
-      composeSubdirectoryPath(
-        COMPOSE_SUBDIRECTORY_PATH_BASE,
+      resolveSubpath(
         modulePackageName,
         exampleAppName,
         EXAMPLE_APP_JS_FILENAME
@@ -340,8 +334,7 @@ Promise.resolve().then(async () => {
       `rewrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workaround solutions`
     )
     await fs.outputFile(
-      composeSubdirectoryPath(
-        COMPOSE_SUBDIRECTORY_PATH_BASE,
+      resolveSubpath(
         modulePackageName,
         exampleAppName,
         EXAMPLE_METRO_CONFIG_FILENAME
@@ -357,11 +350,7 @@ Promise.resolve().then(async () => {
     )
 
     await execa('yarn', ['add', 'link:../'], {
-      cwd: composeSubdirectoryPath(
-        COMPOSE_SUBDIRECTORY_PATH_BASE,
-        modulePackageName,
-        exampleAppName
-      ),
+      cwd: resolveSubpath(modulePackageName, exampleAppName),
       stdout: showReactNativeOutput ? 'inherit' : null,
       stderr: showReactNativeOutput ? 'inherit' : null
     })
@@ -392,12 +381,7 @@ Promise.resolve().then(async () => {
 
       try {
         await execa('pod', ['install'], {
-          cwd: composeSubdirectoryPath(
-            COMPOSE_SUBDIRECTORY_PATH_BASE,
-            modulePackageName,
-            exampleAppName,
-            'ios'
-          ),
+          cwd: resolveSubpath(modulePackageName, exampleAppName, 'ios'),
           stdout: 'inherit',
           stderr: 'inherit'
         })

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -346,7 +346,7 @@ Array [
         "react-native@latest",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-module",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -360,7 +360,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "$CWD/react-native-test-module/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -429,7 +429,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "$CWD/react-native-test-module/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -473,7 +473,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-module/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -519,7 +519,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-module/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -534,7 +534,7 @@ module.exports = {
   Object {
     "log": Array [
       "💡",
-      "check out the example app in $CWD/example",
+      "check out the example app in react-native-test-module/example",
     ],
   },
   Object {
@@ -552,7 +552,7 @@ module.exports = {
   Object {
     "log": Array [
       "[34mℹ[39m",
-      "(cd $CWD/example && yarn start)",
+      "(cd react-native-test-module/example && yarn start)",
     ],
   },
   Object {
@@ -564,7 +564,7 @@ module.exports = {
   Object {
     "log": Array [
       "[34mℹ[39m",
-      "cd $CWD/example",
+      "cd react-native-test-module/example",
     ],
   },
   Object {

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -539,6 +539,12 @@ module.exports = {
   },
   Object {
     "log": Array [
+      "[34mℹ[39m",
+      "(/home/ada.lovelace/path_resolved_from_./react-native-test-module/example)",
+    ],
+  },
+  Object {
+    "log": Array [
       "💡",
       "recommended: run Metro Bundler in a new shell",
     ],

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -61,10 +61,8 @@ jest.mock('path', () => ({
   // with none of the arguments ignored
   resolve: (...paths) =>
     `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
-  // quick solution to ignore first argument which is host-dependent
-  // value of process.cwd()
-  // better solution would be to use path.resolve() instead
-  join: (...parts) => ['$CWD'].concat(parts.slice(1)).join('/')
+  // support functionality of *real* path join operation
+  join: (...paths) => [].concat(paths).join('/')
 }))
 
 it('generate native React Native module with example, with log', async () => {

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -57,6 +57,10 @@ jest.mock('fs-extra', () => ({
 }))
 
 jest.mock('path', () => ({
+  // quick solution to use & log system-independent paths in the snapshots,
+  // with none of the arguments ignored
+  resolve: (...paths) =>
+    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
   // quick solution to ignore first argument which is host-dependent
   // value of process.cwd()
   // better solution would be to use path.resolve() instead

--- a/tests/no-example/no-example-with-log.test.js
+++ b/tests/no-example/no-example-with-log.test.js
@@ -53,13 +53,6 @@ jest.mock('fs-extra', () => ({
   }
 }))
 
-jest.mock('path', () => ({
-  // quick solution to ignore first argument which is host-dependent
-  // value of process.cwd()
-  // better solution would be to use path.resolve() instead
-  join: (...parts) => ['$CWD'].concat(parts.slice(1)).join('/')
-}))
-
 it('generate native React Native module with no example, with log', async () => {
   require('../../main')
 

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -47,13 +47,6 @@ jest.mock('create-react-native-module', () => o => {
   mockCallSnapshot.push({ create: o })
 })
 
-jest.mock('path', () => ({
-  // quick solution to ignore first argument which is host-dependent
-  // value of process.cwd()
-  // better solution would be to use path.resolve() instead
-  join: (...parts) => ['$CWD'].concat(parts.slice(1)).join('/')
-}))
-
 it('generate native React Native view with no example, with log', async () => {
   require('../../../main')
 

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -535,7 +535,7 @@ module.exports = {
   Object {
     "log": Array [
       "💡",
-      "check out the example app in $CWD/example",
+      "check out the example app in react-native-test-view/example",
     ],
   },
   Object {
@@ -553,7 +553,7 @@ module.exports = {
   Object {
     "log": Array [
       "[34mℹ[39m",
-      "(cd $CWD/example && yarn start)",
+      "(cd react-native-test-view/example && yarn start)",
     ],
   },
   Object {
@@ -565,7 +565,7 @@ module.exports = {
   Object {
     "log": Array [
       "[34mℹ[39m",
-      "cd $CWD/example",
+      "cd react-native-test-view/example",
     ],
   },
   Object {

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -359,7 +359,7 @@ Array [
         "react-native@latest",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-view",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -373,7 +373,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "$CWD/react-native-test-view/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -430,7 +430,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "$CWD/react-native-test-view/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -474,7 +474,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-view/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -520,7 +520,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "$CWD/react-native-test-view/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -540,6 +540,12 @@ module.exports = {
   },
   Object {
     "log": Array [
+      "[34mℹ[39m",
+      "(/home/ada.lovelace/path_resolved_from_./react-native-test-view/example)",
+    ],
+  },
+  Object {
+    "log": Array [
       "💡",
       "recommended: run Metro Bundler in a new shell",
     ],

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -61,10 +61,8 @@ jest.mock('path', () => ({
   // with none of the arguments ignored
   resolve: (...paths) =>
     `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
-  // quick solution to ignore first argument which is host-dependent
-  // value of process.cwd()
-  // better solution would be to use path.resolve() instead
-  join: (...parts) => ['$CWD'].concat(parts.slice(1)).join('/')
+  // support functionality of *real* path join operation
+  join: (...paths) => [].concat(paths).join('/')
 }))
 
 it('generate native React Native view with example, with log', async () => {

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -57,6 +57,10 @@ jest.mock('fs-extra', () => ({
 }))
 
 jest.mock('path', () => ({
+  // quick solution to use & log system-independent paths in the snapshots,
+  // with none of the arguments ignored
+  resolve: (...paths) =>
+    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
   // quick solution to ignore first argument which is host-dependent
   // value of process.cwd()
   // better solution would be to use path.resolve() instead


### PR DESCRIPTION
as described in the commits

with some notes in the final commit message:

> ```
> MOTIVATION: The primary motivation of using `path.resolve()` rather
> than `path.join()` is to enable the tests to check the results in a
> less hacky manner.
>
> HOW: This was accomplished by using const helper definitions to
> facilitate the replacement of `process.cwd()` & `path.join`
> in straightforward manner, with a relatively low risk.
> ```

✅ `npm test`
✅ generated library module with example that is working on Android & iOS
✅ generated view module with example that is working on Android & iOS