### PR TITLE
use path.resolve() in example metro.config.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ module.exports = {
   resolver: {
     extraNodeModules: new Proxy(
       {},
-      { get: (_, name) => path.join('.', 'node_modules', name) }
+      { get: (_, name) => path.resolve('.', 'node_modules', name) }
     )
   },
 

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -442,7 +442,7 @@ module.exports = {
   resolver: {
     extraNodeModules: new Proxy(
       {},
-      { get: (_, name) => path.join('.', 'node_modules', name) }
+      { get: (_, name) => path.resolve('.', 'node_modules', name) }
     )
   },
 

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -443,7 +443,7 @@ module.exports = {
   resolver: {
     extraNodeModules: new Proxy(
       {},
-      { get: (_, name) => path.join('.', 'node_modules', name) }
+      { get: (_, name) => path.resolve('.', 'node_modules', name) }
     )
   },
 


### PR DESCRIPTION
instead of path.join()

*potentially* more precise path in workaround for metro symlink issues

similar idea to PR #22

✅ _tested in generated example on Android_