### PR TITLE
add Apple tvOS option

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,7 +197,7 @@ Promise.resolve().then(async () => {
       ? await prompt({
           type: 'confirm',
           name: 'tvosEnabled',
-          message: 'Support Apple tvOS?',
+          message: 'Support Apple tvOS (requires react-native-tvos fork)?',
           initial: false
         })
       : { tvosEnabled: null }

--- a/main.js
+++ b/main.js
@@ -192,6 +192,16 @@ Promise.resolve().then(async () => {
         })
       : { androidPackageId: null }
 
+  const { tvosEnabled } =
+    platforms.indexOf('ios') !== -1
+      ? await prompt({
+          type: 'confirm',
+          name: 'tvosEnabled',
+          message: 'Support Apple tvOS?',
+          initial: false
+        })
+      : { tvosEnabled: null }
+
   // THANKS to @react-native-community/bob for the idea
   // to get user name & email from git
   const gitUserName = (await execa('git', ['config', 'user.name'])).stdout
@@ -291,6 +301,7 @@ Promise.resolve().then(async () => {
     moduleName: modulePackageName,
     packageIdentifier: androidPackageId,
     platforms,
+    tvosEnabled,
     authorName,
     authorEmail,
     view: isView

--- a/main.js
+++ b/main.js
@@ -255,9 +255,14 @@ Promise.resolve().then(async () => {
         await prompt({
           type: 'text',
           name: 'reactNativeVersion',
-          message:
-            'What react-native version to use for the example app (should be at least react-native@0.60)?',
-          initial: 'react-native@latest'
+          message: `What react-native version to use for the example app (should be at least ${
+            tvosEnabled
+              ? 'react-native@npm:react-native-tvos@0.60'
+              : 'react-native@0.60'
+          })?`,
+          initial: tvosEnabled
+            ? 'react-native@npm:react-native-tvos'
+            : 'react-native@latest'
         })
       ).reactNativeVersion
     : null

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -135,6 +135,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "execa": Array [
       "git",
       Array [
@@ -323,6 +336,7 @@ Array [
         "ios",
       ],
       "prefix": "NATIVE",
+      "tvosEnabled": false,
       "view": false,
     },
   },

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -139,7 +139,7 @@ Array [
       "args": Array [
         Object {
           "initial": false,
-          "message": "Support Apple tvOS?",
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
           "name": "tvosEnabled",
           "onState": [Function],
           "type": "confirm",

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -10,6 +10,7 @@ mockPromptResponses = {
   },
   platforms: { platforms: ['android', 'ios'] },
   androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: false },
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   license: { license: 'BSD-4-CLAUSE' },

--- a/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
@@ -135,6 +135,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "execa": Array [
       "git",
       Array [
@@ -242,6 +255,7 @@ Array [
         "ios",
       ],
       "prefix": "NATIVE",
+      "tvosEnabled": false,
       "view": false,
     },
   },

--- a/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
@@ -139,7 +139,7 @@ Array [
       "args": Array [
         Object {
           "initial": false,
-          "message": "Support Apple tvOS?",
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
           "name": "tvosEnabled",
           "onState": [Function],
           "type": "confirm",

--- a/tests/no-example/no-example-with-log.test.js
+++ b/tests/no-example/no-example-with-log.test.js
@@ -10,6 +10,7 @@ mockPromptResponses = {
   },
   platforms: { platforms: ['android', 'ios'] },
   androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: false },
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   license: { license: 'BSD-4-CLAUSE' },

--- a/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
+++ b/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
@@ -1,0 +1,431 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate native React Native view for tvOS, with example 1`] = `
+Array [
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "message": "What is the desired native module name?",
+          "name": "nativeModuleNameInput",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "active": "yes",
+          "inactive": "no",
+          "initial": false,
+          "message": "Should it be a view?",
+          "name": "isView",
+          "onState": [Function],
+          "type": "toggle",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "View name is is TestViewForTvOs. Continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native-test-view-for-tv-os",
+          "message": "What is the full module package name?",
+          "name": "modulePackageName",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Initial package version is 1.0.0 - continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "",
+          "message": "What is the desired native object class name prefix (can be blank)?",
+          "name": "nativeObjectClassNamePrefixInput",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Native class name is NATIVETestViewForTvOs. Continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "choices": Array [
+            Object {
+              "selected": true,
+              "title": "Android",
+              "value": "android",
+            },
+            Object {
+              "selected": true,
+              "title": "iOS",
+              "value": "ios",
+            },
+            Object {
+              "disabled": true,
+              "title": "Windows",
+              "value": "windows",
+            },
+          ],
+          "message": "Which native platforms?",
+          "min": 1,
+          "name": "platforms",
+          "onState": [Function],
+          "type": "multiselect",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.name",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.email",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "Alice",
+          "message": "What is the author name?",
+          "name": "authorName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "alice@example.com",
+          "message": "What is the author email?",
+          "name": "authorEmail",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "MIT",
+          "message": "What license?",
+          "name": "license",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Generate the example app (with workarounds in metro.config.js)?",
+          "name": "generateExampleApp",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "example",
+          "message": "Example app name?",
+          "name": "exampleAppName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native@npm:react-native-tvos",
+          "message": "What react-native version to use for the example app (should be at least react-native@npm:react-native-tvos@0.60)?",
+          "name": "reactNativeVersion",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Show the output of React Native CLI (recommended)?",
+          "name": "showReactNativeOutput",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "execa": Array [
+      "react-native",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "yarn",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "create": Object {
+      "authorEmail": "ada@lovelace.name",
+      "authorName": "Ada",
+      "moduleName": "react-native-tvos-test-view",
+      "name": "TestViewForTvOs",
+      "packageIdentifier": "com.test",
+      "platforms": Array [
+        "android",
+        "ios",
+      ],
+      "prefix": "NATIVE",
+      "tvosEnabled": true,
+      "view": true,
+    },
+  },
+  Object {
+    "execa": Array [
+      "react-native",
+      Array [
+        "init",
+        "example",
+        "--version",
+        "react-native-tvos@latest",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+  Object {
+    "outputFile": Object {
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/App.js",
+      "outputContents": "/**
+ * Sample React Native App
+ *
+ * adapted from App.js generated by the following command:
+ *
+ * react-native init example
+ *
+ * https://github.com/facebook/react-native
+ */
+
+import React, { Component } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import TestViewForTvOs from 'react-native-tvos-test-view';
+
+export default class App extends Component<{}> {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>☆TestViewForTvOs example☆</Text>
+        <Text style={styles.instructions}>STATUS: loaded</Text>
+        <Text style={styles.welcome}>☆☆☆</Text>
+        <TestViewForTvOs />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
+",
+    },
+  },
+  Object {
+    "outputFile": Object {
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/metro.config.js",
+      "outputContents": "// metro.config.js
+// with workaround solutions
+
+const path = require('path')
+
+module.exports = {
+  // workaround for issue with symlinks encountered starting with
+  // metro@0.55 / React Native 0.61
+  // (not needed with React Native 0.60 / metro@0.54)
+  resolver: {
+    extraNodeModules: new Proxy(
+      {},
+      { get: (_, name) => path.resolve('.', 'node_modules', name) }
+    )
+  },
+
+  // quick workaround solution for issue with symlinked modules ref:
+  // https://github.com/brodybits/create-react-native-module/issues/232
+  watchFolders: ['.', '..']
+}
+",
+    },
+  },
+  Object {
+    "execa": Array [
+      "yarn",
+      Array [
+        "add",
+        "link:../",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+  Object {
+    "execa": Array [
+      "pod",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "pod",
+      Array [
+        "install",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/ios",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+]
+`;

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -1,0 +1,76 @@
+const mockCallSnapshot = []
+
+mockPromptResponses = {
+  nativeModuleNameInput: { nativeModuleNameInput: 'test view for tvOS' },
+  isView: { isView: true },
+  confirmation: { confirmation: true },
+  modulePackageName: { modulePackageName: 'react-native-tvos-test-view' },
+  nativeObjectClassNamePrefixInput: {
+    nativeObjectClassNamePrefixInput: 'native'
+  },
+  platforms: { platforms: ['android', 'ios'] },
+  androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: true },
+  authorName: { authorName: 'Ada' },
+  authorEmail: { authorEmail: 'ada@lovelace.name' },
+  license: { license: 'BSD-4-CLAUSE' },
+  generateExampleApp: { generateExampleApp: true },
+  reactNativeVersion: { reactNativeVersion: 'react-native-tvos@latest' },
+  exampleAppName: { exampleAppName: 'example' },
+  showReactNativeOutput: { showReactNativeOutput: true }
+}
+
+jest.mock('console', () => ({
+  log: (..._) => {
+    /* do nothing */
+  }
+}))
+
+jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
+  mockCallSnapshot.push({ prompts: { args } })
+  const optionsArray = [].concat(args)
+  expect(optionsArray.length).toBe(1)
+  return Promise.resolve(mockPromptResponses[optionsArray[0].name])
+})
+
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
+  if (cmd === 'git') {
+    if (args[1] == 'user.email')
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    else
+      return Promise.resolve({
+        stdout: 'Alice'
+      })
+  } else {
+    return Promise.resolve()
+  }
+})
+
+jest.mock('create-react-native-module', () => o => {
+  mockCallSnapshot.push({ create: o })
+})
+
+jest.mock('fs-extra', () => ({
+  outputFile: (filePath, outputContents) => {
+    mockCallSnapshot.push({ outputFile: { filePath, outputContents } })
+  }
+}))
+
+jest.mock('path', () => ({
+  // quick solution to use & log system-independent paths in the snapshots,
+  // with none of the arguments ignored
+  resolve: (...paths) =>
+    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
+  // support functionality of *real* path join operation
+  join: (...paths) => [].concat(paths).join('/')
+}))
+
+it('generate native React Native view for tvOS, with example', async () => {
+  require('../../../main')
+
+  await new Promise(resolve => setTimeout(resolve, 0.001))
+
+  expect(mockCallSnapshot).toMatchSnapshot()
+})

--- a/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
+++ b/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
@@ -229,8 +229,8 @@ Array [
     "prompts": Object {
       "args": Array [
         Object {
-          "initial": "react-native@latest",
-          "message": "What react-native version to use for the example app (should be at least react-native@0.60)?",
+          "initial": "react-native@npm:react-native-tvos",
+          "message": "What react-native version to use for the example app (should be at least react-native@npm:react-native-tvos@0.60)?",
           "name": "reactNativeVersion",
           "onState": [Function],
           "type": "text",

--- a/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
+++ b/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
@@ -1,0 +1,430 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate native React Native module for tvOS with example 1`] = `
+Array [
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "message": "What is the desired native module name?",
+          "name": "nativeModuleNameInput",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "active": "yes",
+          "inactive": "no",
+          "initial": false,
+          "message": "Should it be a view?",
+          "name": "isView",
+          "onState": [Function],
+          "type": "toggle",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native-test-module-for-tv-os",
+          "message": "What is the full module package name?",
+          "name": "modulePackageName",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Initial package version is 1.0.0 - continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "",
+          "message": "What is the desired native object class name prefix (can be blank)?",
+          "name": "nativeObjectClassNamePrefixInput",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Native class name is NATIVETestModuleForTvOs. Continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "choices": Array [
+            Object {
+              "selected": true,
+              "title": "Android",
+              "value": "android",
+            },
+            Object {
+              "selected": true,
+              "title": "iOS",
+              "value": "ios",
+            },
+            Object {
+              "disabled": true,
+              "title": "Windows",
+              "value": "windows",
+            },
+          ],
+          "message": "Which native platforms?",
+          "min": 1,
+          "name": "platforms",
+          "onState": [Function],
+          "type": "multiselect",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.name",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.email",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "Alice",
+          "message": "What is the author name?",
+          "name": "authorName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "alice@example.com",
+          "message": "What is the author email?",
+          "name": "authorEmail",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "MIT",
+          "message": "What license?",
+          "name": "license",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Generate the example app (with workarounds in metro.config.js)?",
+          "name": "generateExampleApp",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "example",
+          "message": "Example app name?",
+          "name": "exampleAppName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native@latest",
+          "message": "What react-native version to use for the example app (should be at least react-native@0.60)?",
+          "name": "reactNativeVersion",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Show the output of React Native CLI (recommended)?",
+          "name": "showReactNativeOutput",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "execa": Array [
+      "react-native",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "yarn",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "create": Object {
+      "authorEmail": "ada@lovelace.name",
+      "authorName": "Ada",
+      "moduleName": "react-native-tvos-test-module",
+      "name": "test module for tvOS",
+      "packageIdentifier": "com.test",
+      "platforms": Array [
+        "android",
+        "ios",
+      ],
+      "prefix": "NATIVE",
+      "tvosEnabled": true,
+      "view": false,
+    },
+  },
+  Object {
+    "execa": Array [
+      "react-native",
+      Array [
+        "init",
+        "example",
+        "--version",
+        "react-native-tvos@latest",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+  Object {
+    "outputFile": Object {
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/App.js",
+      "outputContents": "/**
+ * Sample React Native App
+ *
+ * adapted from App.js generated by the following command:
+ *
+ * react-native init example
+ *
+ * https://github.com/facebook/react-native
+ */
+
+import React, { Component } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import test module for tvOS from 'react-native-tvos-test-module';
+
+export default class App extends Component<{}> {
+  state = {
+    status: 'starting',
+    message: '--'
+  };
+  componentDidMount() {
+    test module for tvOS.sampleMethod('Testing', 123, (message) => {
+      this.setState({
+        status: 'native callback received',
+        message
+      });
+    });
+  }
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>☆test module for tvOS example☆</Text>
+        <Text style={styles.instructions}>STATUS: {this.state.status}</Text>
+        <Text style={styles.welcome}>☆NATIVE CALLBACK MESSAGE☆</Text>
+        <Text style={styles.instructions}>{this.state.message}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
+",
+    },
+  },
+  Object {
+    "outputFile": Object {
+      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/metro.config.js",
+      "outputContents": "// metro.config.js
+// with workaround solutions
+
+const path = require('path')
+
+module.exports = {
+  // workaround for issue with symlinks encountered starting with
+  // metro@0.55 / React Native 0.61
+  // (not needed with React Native 0.60 / metro@0.54)
+  resolver: {
+    extraNodeModules: new Proxy(
+      {},
+      { get: (_, name) => path.resolve('.', 'node_modules', name) }
+    )
+  },
+
+  // quick workaround solution for issue with symlinked modules ref:
+  // https://github.com/brodybits/create-react-native-module/issues/232
+  watchFolders: ['.', '..']
+}
+",
+    },
+  },
+  Object {
+    "execa": Array [
+      "yarn",
+      Array [
+        "add",
+        "link:../",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+  Object {
+    "execa": Array [
+      "pod",
+      Array [
+        "--version",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "pod",
+      Array [
+        "install",
+      ],
+      Object {
+        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/ios",
+        "stderr": "inherit",
+        "stdout": "inherit",
+      },
+    ],
+  },
+]
+`;

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -1,0 +1,76 @@
+const mockCallSnapshot = []
+
+mockPromptResponses = {
+  nativeModuleNameInput: { nativeModuleNameInput: 'test module for tvOS' },
+  isView: { isView: false },
+  confirmation: { confirmation: true },
+  modulePackageName: { modulePackageName: 'react-native-tvos-test-module' },
+  nativeObjectClassNamePrefixInput: {
+    nativeObjectClassNamePrefixInput: 'native'
+  },
+  platforms: { platforms: ['android', 'ios'] },
+  androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: true },
+  authorName: { authorName: 'Ada' },
+  authorEmail: { authorEmail: 'ada@lovelace.name' },
+  license: { license: 'BSD-4-CLAUSE' },
+  generateExampleApp: { generateExampleApp: true },
+  reactNativeVersion: { reactNativeVersion: 'react-native-tvos@latest' },
+  exampleAppName: { exampleAppName: 'example' },
+  showReactNativeOutput: { showReactNativeOutput: true }
+}
+
+jest.mock('console', () => ({
+  log: (..._) => {
+    /* do nothing */
+  }
+}))
+
+jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
+  mockCallSnapshot.push({ prompts: { args } })
+  const optionsArray = [].concat(args)
+  expect(optionsArray.length).toBe(1)
+  return Promise.resolve(mockPromptResponses[optionsArray[0].name])
+})
+
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
+  if (cmd === 'git') {
+    if (args[1] == 'user.email')
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    else
+      return Promise.resolve({
+        stdout: 'Alice'
+      })
+  } else {
+    return Promise.resolve()
+  }
+})
+
+jest.mock('create-react-native-module', () => o => {
+  mockCallSnapshot.push({ create: o })
+})
+
+jest.mock('fs-extra', () => ({
+  outputFile: (filePath, outputContents) => {
+    mockCallSnapshot.push({ outputFile: { filePath, outputContents } })
+  }
+}))
+
+jest.mock('path', () => ({
+  // quick solution to use & log system-independent paths in the snapshots,
+  // with none of the arguments ignored
+  resolve: (...paths) =>
+    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
+  // support functionality of *real* path join operation
+  join: (...paths) => [].concat(paths).join('/')
+}))
+
+it('generate native React Native module for tvOS with example', async () => {
+  require('../../../main')
+
+  await new Promise(resolve => setTimeout(resolve, 0.001))
+
+  expect(mockCallSnapshot).toMatchSnapshot()
+})

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -152,7 +152,7 @@ Array [
       "args": Array [
         Object {
           "initial": false,
-          "message": "Support Apple tvOS?",
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
           "name": "tvosEnabled",
           "onState": [Function],
           "type": "confirm",

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -148,6 +148,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "execa": Array [
       "git",
       Array [
@@ -255,6 +268,7 @@ Array [
         "ios",
       ],
       "prefix": "NATIVE",
+      "tvosEnabled": false,
       "view": true,
     },
   },

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -10,6 +10,7 @@ mockPromptResponses = {
   },
   platforms: { platforms: ['android', 'ios'] },
   androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: false },
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   license: { license: 'BSD-4-CLAUSE' },

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -152,7 +152,7 @@ Array [
       "args": Array [
         Object {
           "initial": false,
-          "message": "Support Apple tvOS?",
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
           "name": "tvosEnabled",
           "onState": [Function],
           "type": "confirm",

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -148,6 +148,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "execa": Array [
       "git",
       Array [
@@ -336,6 +349,7 @@ Array [
         "ios",
       ],
       "prefix": "NATIVE",
+      "tvosEnabled": false,
       "view": true,
     },
   },

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -10,6 +10,7 @@ mockPromptResponses = {
   },
   platforms: { platforms: ['android', 'ios'] },
   androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: false },
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   license: { license: 'BSD-4-CLAUSE' },


### PR DESCRIPTION
with some TODO items _- updated_:

- [x] ~~remove extra cleanup update that is now in PR #25~~
- [x] ~~update test snapshots~~
- [x] use react-native-tvos for example by default if tvOS support is enabled
- [x] test with generated example on tvOS
- [x] test view with generated example on tvOS

resolves _one_ of the missing options discussed in issue #9