### PR TITLE
cleanup prompts usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -183,11 +183,10 @@ Promise.resolve().then(async () => {
 
   const { androidPackageId } =
     platforms.indexOf('android') !== -1
-      ? await prompts({
+      ? await prompt({
           type: 'text',
           name: 'androidPackageId',
           message: 'What is the desired Android package id?',
-          onState,
           initial: 'com.demo',
           validate: androidPackageId => androidPackageId.length > 0
         })

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -122,14 +122,16 @@ Array [
   },
   Object {
     "prompts": Object {
-      "args": Object {
-        "initial": "com.demo",
-        "message": "What is the desired Android package id?",
-        "name": "androidPackageId",
-        "onState": [Function],
-        "type": "text",
-        "validate": [Function],
-      },
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
     },
   },
   Object {

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -26,6 +26,7 @@ jest.mock('console', () => ({
 }))
 
 jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
   mockCallSnapshot.push({ prompts: { args } })
   const optionsArray = [].concat(args)
   expect(optionsArray.length).toBe(1)

--- a/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
@@ -122,14 +122,16 @@ Array [
   },
   Object {
     "prompts": Object {
-      "args": Object {
-        "initial": "com.demo",
-        "message": "What is the desired Android package id?",
-        "name": "androidPackageId",
-        "onState": [Function],
-        "type": "text",
-        "validate": [Function],
-      },
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
     },
   },
   Object {

--- a/tests/no-example/no-example-with-log.test.js
+++ b/tests/no-example/no-example-with-log.test.js
@@ -23,6 +23,7 @@ jest.mock('console', () => ({
 }))
 
 jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
   mockCallSnapshot.push({ prompts: { args } })
   const optionsArray = [].concat(args)
   expect(optionsArray.length).toBe(1)

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -135,14 +135,16 @@ Array [
   },
   Object {
     "prompts": Object {
-      "args": Object {
-        "initial": "com.demo",
-        "message": "What is the desired Android package id?",
-        "name": "androidPackageId",
-        "onState": [Function],
-        "type": "text",
-        "validate": [Function],
-      },
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
     },
   },
   Object {

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -23,6 +23,7 @@ jest.mock('console', () => ({
 }))
 
 jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
   mockCallSnapshot.push({ prompts: { args } })
   const optionsArray = [].concat(args)
   expect(optionsArray.length).toBe(1)

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -135,14 +135,16 @@ Array [
   },
   Object {
     "prompts": Object {
-      "args": Object {
-        "initial": "com.demo",
-        "message": "What is the desired Android package id?",
-        "name": "androidPackageId",
-        "onState": [Function],
-        "type": "text",
-        "validate": [Function],
-      },
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
     },
   },
   Object {

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -26,6 +26,7 @@ jest.mock('console', () => ({
 }))
 
 jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
   mockCallSnapshot.push({ prompts: { args } })
   const optionsArray = [].concat(args)
   expect(optionsArray.length).toBe(1)


### PR DESCRIPTION
- cleanup: use prompt helper for Android package id (internal prompt helper function)
- check that prompts argument is array in one of the existing test cases (init-with-example-with-log.test.js)

Testing:

- [x] `npx test` passes
- [x] verify ability to generate a working library module with custom Android package ID (using generated example project)

(includes _some_ of the changes from PR #25)