### PR TITLE
option to include sample use of Apple Networking

### DIFF
--- a/main.js
+++ b/main.js
@@ -235,6 +235,16 @@ Promise.resolve().then(async () => {
     initial: 'MIT'
   })
 
+  const { useAppleNetworking } =
+    platforms.indexOf('ios') !== -1 && !isView
+      ? await prompt({
+          type: 'confirm',
+          name: 'useAppleNetworking',
+          message: 'Generate with sample use of Apple Networking?',
+          initial: false
+        })
+      : { useAppleNetworking: false }
+
   log(INFO, 'It is possible to generate an example test app,')
   log(INFO, 'with workarounds in metro.config.js for metro linking issues')
   log(INFO, 'Requirements: react-native-cli and Yarn; pod is needed for iOS')
@@ -317,7 +327,8 @@ Promise.resolve().then(async () => {
     authorName,
     authorEmail,
     githubAccount: githubUserAccountName,
-    view: isView
+    view: isView,
+    useAppleNetworking
   }
 
   createReactNativeLibraryModule(createOptions)

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -220,6 +220,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Generate with sample use of Apple Networking?",
+          "name": "useAppleNetworking",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "log": Array [
       "ℹ",
       "It is possible to generate an example test app,",
@@ -351,6 +364,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": false,
+      "useAppleNetworking": false,
       "view": false,
     },
   },

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -15,6 +15,7 @@ mockPromptResponses = {
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
   license: { license: 'BSD-4-CLAUSE' },
+  useAppleNetworking: { useAppleNetworking: false },
   generateExampleApp: { generateExampleApp: true },
   reactNativeVersion: { reactNativeVersion: 'react-native@latest' },
   exampleAppName: { exampleAppName: 'example' },

--- a/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-with-log.test.js.snap
@@ -220,6 +220,19 @@ Array [
     },
   },
   Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Generate with sample use of Apple Networking?",
+          "name": "useAppleNetworking",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
     "log": Array [
       "ℹ",
       "It is possible to generate an example test app,",
@@ -270,6 +283,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": false,
+      "useAppleNetworking": false,
       "view": false,
     },
   },

--- a/tests/no-example/no-example-with-log.test.js
+++ b/tests/no-example/no-example-with-log.test.js
@@ -13,6 +13,7 @@ mockPromptResponses = {
   tvosEnabled: { tvosEnabled: false },
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
+  useAppleNetworking: { useAppleNetworking: false },
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: false }

--- a/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
+++ b/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
@@ -309,6 +309,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": true,
+      "useAppleNetworking": false,
       "view": true,
     },
   },

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -14,6 +14,7 @@ mockPromptResponses = {
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
+  useAppleNetworking: { useAppleNetworking: false },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: true },
   reactNativeVersion: { reactNativeVersion: 'react-native-tvos@latest' },

--- a/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
+++ b/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
@@ -216,6 +216,19 @@ Array [
     "prompts": Object {
       "args": Array [
         Object {
+          "initial": false,
+          "message": "Generate with sample use of Apple Networking?",
+          "name": "useAppleNetworking",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
           "initial": true,
           "message": "Generate the example app (with workarounds in metro.config.js)?",
           "name": "generateExampleApp",
@@ -296,6 +309,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": true,
+      "useAppleNetworking": false,
       "view": false,
     },
   },

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -14,6 +14,7 @@ mockPromptResponses = {
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
+  useAppleNetworking: { useAppleNetworking: false },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: true },
   reactNativeVersion: { reactNativeVersion: 'react-native-tvos@latest' },

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -283,6 +283,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": false,
+      "useAppleNetworking": false,
       "view": true,
     },
   },

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -14,6 +14,7 @@ mockPromptResponses = {
   authorName: { authorName: 'Ada' },
   authorEmail: { authorEmail: 'ada@lovelace.name' },
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
+  useAppleNetworking: { useAppleNetworking: false },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: false }
 }

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -364,6 +364,7 @@ Array [
       ],
       "prefix": "NATIVE",
       "tvosEnabled": false,
+      "useAppleNetworking": false,
       "view": true,
     },
   },

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -16,6 +16,7 @@ mockPromptResponses = {
   githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
   license: { license: 'BSD-4-CLAUSE' },
   generateExampleApp: { generateExampleApp: true },
+  useAppleNetworking: { useAppleNetworking: false },
   reactNativeVersion: { reactNativeVersion: 'react-native@latest' },
   exampleAppName: { exampleAppName: 'example' },
   showReactNativeOutput: { showReactNativeOutput: true }

--- a/tests/with-apple-networking/__snapshots__/with-apple-networking.test.js.snap
+++ b/tests/with-apple-networking/__snapshots__/with-apple-networking.test.js.snap
@@ -1,0 +1,260 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate native React Native module with no example, with log 1`] = `
+Array [
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "message": "What is the desired native module name?",
+          "name": "nativeModuleNameInput",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "active": "yes",
+          "inactive": "no",
+          "initial": false,
+          "message": "Should it be a view?",
+          "name": "isView",
+          "onState": [Function],
+          "type": "toggle",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "react-native-test-module",
+          "message": "What is the full module package name?",
+          "name": "modulePackageName",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Initial package version is 1.0.0 - continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "",
+          "message": "What is the desired native object class name prefix (can be blank)?",
+          "name": "nativeObjectClassNamePrefixInput",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Native class name is NATIVETestModule. Continue?",
+          "name": "confirmation",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "choices": Array [
+            Object {
+              "selected": true,
+              "title": "Android",
+              "value": "android",
+            },
+            Object {
+              "selected": true,
+              "title": "iOS",
+              "value": "ios",
+            },
+            Object {
+              "disabled": true,
+              "title": "Windows",
+              "value": "windows",
+            },
+          ],
+          "message": "Which native platforms?",
+          "min": 1,
+          "name": "platforms",
+          "onState": [Function],
+          "type": "multiselect",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "com.demo",
+          "message": "What is the desired Android package id?",
+          "name": "androidPackageId",
+          "onState": [Function],
+          "type": "text",
+          "validate": [Function],
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Support Apple tvOS (requires react-native-tvos fork)?",
+          "name": "tvosEnabled",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.name",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "execa": Array [
+      "git",
+      Array [
+        "config",
+        "user.email",
+      ],
+      undefined,
+    ],
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "Alice",
+          "message": "What is the author name?",
+          "name": "authorName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "alice@example.com",
+          "message": "What is the author email?",
+          "name": "authorEmail",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "ada",
+          "message": "What is the GitHub user account name?",
+          "name": "githubUserAccountName",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": "MIT",
+          "message": "What license?",
+          "name": "license",
+          "onState": [Function],
+          "type": "text",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": false,
+          "message": "Generate with sample use of Apple Networking?",
+          "name": "useAppleNetworking",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "prompts": Object {
+      "args": Array [
+        Object {
+          "initial": true,
+          "message": "Generate the example app (with workarounds in metro.config.js)?",
+          "name": "generateExampleApp",
+          "onState": [Function],
+          "type": "confirm",
+        },
+      ],
+    },
+  },
+  Object {
+    "create": Object {
+      "authorEmail": "ada@lovelace.name",
+      "authorName": "Ada",
+      "githubAccount": "ada-lovelace",
+      "moduleName": "react-native-test-module",
+      "name": "test Module",
+      "packageIdentifier": "com.test",
+      "platforms": Array [
+        "android",
+        "ios",
+      ],
+      "prefix": "NATIVE",
+      "tvosEnabled": false,
+      "useAppleNetworking": true,
+      "view": false,
+    },
+  },
+]
+`;

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -1,0 +1,60 @@
+const mockCallSnapshot = []
+
+mockPromptResponses = {
+  nativeModuleNameInput: { nativeModuleNameInput: 'test Module' },
+  isView: { isView: false },
+  confirmation: { confirmation: true },
+  modulePackageName: { modulePackageName: 'react-native-test-module' },
+  nativeObjectClassNamePrefixInput: {
+    nativeObjectClassNamePrefixInput: 'native'
+  },
+  platforms: { platforms: ['android', 'ios'] },
+  androidPackageId: { androidPackageId: 'com.test' },
+  tvosEnabled: { tvosEnabled: false },
+  authorName: { authorName: 'Ada' },
+  authorEmail: { authorEmail: 'ada@lovelace.name' },
+  useAppleNetworking: { useAppleNetworking: true },
+  githubUserAccountName: { githubUserAccountName: 'ada-lovelace' },
+  license: { license: 'BSD-4-CLAUSE' },
+  generateExampleApp: { generateExampleApp: false }
+}
+
+jest.mock('console', () => ({
+  log: (...args) => {
+    /* do nothing */
+  }
+}))
+
+jest.mock('prompts', () => args => {
+  expect(Array.isArray(args)).toBe(true)
+  mockCallSnapshot.push({ prompts: { args } })
+  const optionsArray = [].concat(args)
+  expect(optionsArray.length).toBe(1)
+  return Promise.resolve(mockPromptResponses[optionsArray[0].name])
+})
+
+jest.mock('execa', () => (cmd, args, opts) => {
+  mockCallSnapshot.push({ execa: [cmd, args, opts] })
+  if (cmd === 'git') {
+    if (args[1] == 'user.email')
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    else
+      return Promise.resolve({
+        stdout: 'Alice'
+      })
+  } else {
+    return Promise.resolve()
+  }
+})
+
+jest.mock('create-react-native-module', () => o => {
+  mockCallSnapshot.push({ create: o })
+})
+
+it('generate native React Native module with no example, with log', async () => {
+  require('../../main')
+
+  await new Promise(resolve => setTimeout(resolve, 0.001))
+
+  expect(mockCallSnapshot).toMatchSnapshot()
+})


### PR DESCRIPTION
last missing option listed in issue #8

resolves #8

✅ `npm test` ok
✅ able to generate library module with the sample use of Apple Networking included