### PR TITLE
use correct license in generated module or view

### DIFF
--- a/main.js
+++ b/main.js
@@ -333,6 +333,7 @@ Promise.resolve().then(async () => {
     authorName,
     authorEmail,
     githubAccount: githubUserAccountName,
+    license,
     view: isView,
     useAppleNetworking
   }

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -356,6 +356,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestModule",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-test-module",
       "name": "test Module",
       "packageIdentifier": "com.test",

--- a/tests/no-example/__snapshots__/no-example-module-all.test.js.snap
+++ b/tests/no-example/__snapshots__/no-example-module-all.test.js.snap
@@ -283,6 +283,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestModule",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-test-module",
       "name": "test Module",
       "packageIdentifier": "com.test",

--- a/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
+++ b/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
@@ -301,6 +301,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestView",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-tvos-test-view",
       "name": "TestViewForTvOs",
       "packageIdentifier": "com.test",

--- a/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
+++ b/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
@@ -301,6 +301,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestModule",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-tvos-test-module",
       "name": "test module for tvOS",
       "packageIdentifier": "com.test",

--- a/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
+++ b/tests/view/no-example/__snapshots__/init-view-no-example-with-log.test.js.snap
@@ -275,6 +275,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestView",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-test-view",
       "name": "TestView",
       "packageIdentifier": "com.test",

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -356,6 +356,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestView",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-test-view",
       "name": "TestView",
       "packageIdentifier": "com.test",

--- a/tests/with-apple-networking/__snapshots__/with-apple-networking.test.js.snap
+++ b/tests/with-apple-networking/__snapshots__/with-apple-networking.test.js.snap
@@ -244,6 +244,7 @@ Array [
       "authorName": "Ada",
       "className": "SUPERTestModule",
       "githubAccount": "ada-lovelace",
+      "license": "BSD-4-CLAUSE",
       "moduleName": "react-native-test-module",
       "name": "test Module",
       "packageIdentifier": "com.test",


### PR DESCRIPTION
resolves #56

(issue was discovered by running prettier-standard with `--lint` flag)