### PR TITLE
use full example path for overwrites, etc.

### DIFF
--- a/main.js
+++ b/main.js
@@ -348,6 +348,8 @@ Promise.resolve().then(async () => {
 
     const generateExampleAppOptions = ['--version', reactNativeVersion]
 
+    const exampleAppPath = resolveSubpath(modulePackageName, exampleAppName)
+
     await execa(
       'react-native',
       ['init', exampleAppName].concat(generateExampleAppOptions),
@@ -361,11 +363,7 @@ Promise.resolve().then(async () => {
     log(INFO, 'generating App.js in the example app')
 
     await fs.outputFile(
-      resolveSubpath(
-        modulePackageName,
-        exampleAppName,
-        EXAMPLE_APP_JS_FILENAME
-      ),
+      resolveSubpath(exampleAppPath, EXAMPLE_APP_JS_FILENAME),
       exampleAppTemplate.content({
         ...createOptions,
         name: nativeObjectClassName
@@ -378,11 +376,7 @@ Promise.resolve().then(async () => {
       `rewrite ${EXAMPLE_METRO_CONFIG_FILENAME} with workaround solutions`
     )
     await fs.outputFile(
-      resolveSubpath(
-        modulePackageName,
-        exampleAppName,
-        EXAMPLE_METRO_CONFIG_FILENAME
-      ),
+      resolveSubpath(exampleAppPath, EXAMPLE_METRO_CONFIG_FILENAME),
       EXAMPLE_METRO_CONFIG_WORKAROUND
     )
 
@@ -394,7 +388,7 @@ Promise.resolve().then(async () => {
     )
 
     await execa('yarn', ['add', 'link:../'], {
-      cwd: resolveSubpath(modulePackageName, exampleAppName),
+      cwd: exampleAppPath,
       stdout: showReactNativeOutput ? 'inherit' : null,
       stderr: showReactNativeOutput ? 'inherit' : null
     })
@@ -425,7 +419,7 @@ Promise.resolve().then(async () => {
 
       try {
         await execa('pod', ['install'], {
-          cwd: resolveSubpath(modulePackageName, exampleAppName, 'ios'),
+          cwd: resolveSubpath(exampleAppPath, 'ios'),
           stdout: 'inherit',
           stderr: 'inherit'
         })
@@ -436,10 +430,9 @@ Promise.resolve().then(async () => {
       log(OK, 'additional pod install ok')
     }
 
-    // to show the subdirectory path of the example app
-    // (both relative & absolute):
+    // to show relative the subdirectory path of the example app
+    // (in addition to the absolute subdirectory path):
     const exampleAppSubdirectory = joinPath(modulePackageName, exampleAppName)
-    const exampleAppPath = resolveSubpath(modulePackageName, exampleAppName)
     // show the example app info:
     log(BULB, `check out the example app in ${exampleAppSubdirectory}`)
     log(INFO, `(${exampleAppPath})`)

--- a/main.js
+++ b/main.js
@@ -68,8 +68,14 @@ module.exports = {
 }
 `
 
+// resolve the process cwd for once
+// equivalent to using process.cwd ref:
+// https://stackoverflow.com/a/9874415
+// (resolve('.') is a little easier to mock at this point)
+const cwdPath = path.resolve('.')
+
 // path helpers:
-const resolveSubpath = (...paths) => path.resolve('.', ...paths)
+const resolveSubpath = (...paths) => path.resolve(...paths)
 const joinPath = path.join
 
 // quick workaround ref:
@@ -348,13 +354,15 @@ Promise.resolve().then(async () => {
 
     const generateExampleAppOptions = ['--version', reactNativeVersion]
 
-    const exampleAppPath = resolveSubpath(modulePackageName, exampleAppName)
+    const modulePath = resolveSubpath(cwdPath, modulePackageName)
+
+    const exampleAppPath = resolveSubpath(modulePath, exampleAppName)
 
     await execa(
       'react-native',
       ['init', exampleAppName].concat(generateExampleAppOptions),
       {
-        cwd: resolveSubpath(modulePackageName),
+        cwd: modulePath,
         stdout: showReactNativeOutput ? 'inherit' : null,
         stderr: showReactNativeOutput ? 'inherit' : null
       }

--- a/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
+++ b/tests/init-with-example/__snapshots__/init-with-example-with-log.test.js.snap
@@ -391,7 +391,7 @@ Array [
         "react-native@latest",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-test-module",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -405,7 +405,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-test-module/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -474,7 +474,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -518,7 +518,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-test-module/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -564,7 +564,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-module/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-test-module/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -585,7 +585,7 @@ module.exports = {
   Object {
     "log": Array [
       "ℹ",
-      "(/home/ada.lovelace/path_resolved_from_./react-native-test-module/example)",
+      "(/home/ada.lovelace/path_resolved_from/react-native-test-module/example)",
     ],
   },
   Object {

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -65,7 +65,9 @@ jest.mock('path', () => ({
   // quick solution to use & log system-independent paths in the snapshots,
   // with none of the arguments ignored
   resolve: (...paths) =>
-    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
+    paths.length === 1 && paths[0] === '.'
+      ? '/home/ada.lovelace/path_resolved_from'
+      : paths.join('/'),
   // support functionality of *real* path join operation
   join: (...paths) => [].concat(paths).join('/')
 }))

--- a/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
+++ b/tests/tvos/view-with-example/__snapshots__/tvos-view-with-example.test.js.snap
@@ -324,7 +324,7 @@ Array [
         "react-native-tvos@latest",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-view",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -332,7 +332,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-view/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -383,7 +383,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-view/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -415,7 +415,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-view/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -437,7 +437,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-view/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-view/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -65,7 +65,9 @@ jest.mock('path', () => ({
   // quick solution to use & log system-independent paths in the snapshots,
   // with none of the arguments ignored
   resolve: (...paths) =>
-    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
+    paths.length === 1 && paths[0] === '.'
+      ? '/home/ada.lovelace/path_resolved_from'
+      : paths.join('/'),
   // support functionality of *real* path join operation
   join: (...paths) => [].concat(paths).join('/')
 }))

--- a/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
+++ b/tests/tvos/with-example/__snapshots__/tvos-with-example.test.js.snap
@@ -324,7 +324,7 @@ Array [
         "react-native-tvos@latest",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-module",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -332,7 +332,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-module/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -395,7 +395,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-module/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -427,7 +427,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-module/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -449,7 +449,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-tvos-test-module/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from/react-native-tvos-test-module/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -65,7 +65,9 @@ jest.mock('path', () => ({
   // quick solution to use & log system-independent paths in the snapshots,
   // with none of the arguments ignored
   resolve: (...paths) =>
-    `/home/ada.lovelace/path_resolved_from_${paths.join('/')}`,
+    paths.length === 1 && paths[0] === '.'
+      ? '/home/ada.lovelace/path_resolved_from'
+      : paths.join('/'),
   // support functionality of *real* path join operation
   join: (...paths) => [].concat(paths).join('/')
 }))

--- a/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
+++ b/tests/view/with-example/__snapshots__/init-view-with-example-with-log.test.js.snap
@@ -391,7 +391,7 @@ Array [
         "react-native@latest",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view",
+        "cwd": "/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -405,7 +405,7 @@ Array [
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/App.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/App.js",
       "outputContents": "/**
  * Sample React Native App
  *
@@ -462,7 +462,7 @@ const styles = StyleSheet.create({
   },
   Object {
     "outputFile": Object {
-      "filePath": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/metro.config.js",
+      "filePath": "/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/metro.config.js",
       "outputContents": "// metro.config.js
 // with workaround solutions
 
@@ -506,7 +506,7 @@ module.exports = {
         "link:../",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example",
+        "cwd": "/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view/example",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -552,7 +552,7 @@ module.exports = {
         "install",
       ],
       Object {
-        "cwd": "/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/ios",
+        "cwd": "/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view/example/ios",
         "stderr": "inherit",
         "stdout": "inherit",
       },
@@ -573,7 +573,7 @@ module.exports = {
   Object {
     "log": Array [
       "ℹ",
-      "(/home/ada.lovelace/path_resolved_from_./react-native-test-view/example)",
+      "(/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_/home/ada.lovelace/path_resolved_from_./react-native-test-view/example)",
     ],
   },
   Object {


### PR DESCRIPTION
and avoid computing the example path multiple times

This improvement was discovered while working on (draft) PR #53.

TESTING:

- [x] generated native module with example on Android & iOS
- [x] generated native view with example on Android & iOS
- [x] update test mocks to handle path.resolve for absolute path vs subdirectory path