### PR TITLE
add & use run-scripts for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "cross-env": "^7.0.3",
     "hexyjs": "^2.1.4",
     "jest": "^26.6.3",
-    "prettierx": "^0.14.3"
+    "prettierx": "^0.14.3",
+    "run-scripts": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "main.js"
   ],
   "scripts": {
-    "jest": "cross-env CI=true jest",
     "lint": "npm run prettier",
     "// lint notes": [
       "The prettierx CLI is now used (directly) to check & fix formatting",
@@ -38,7 +37,8 @@
       "cross-env CI=true seems to be needed to get the same results with",
       "some emoji symbols on both macOS workstation and GitHub Workflow"
     ],
-    "test": "run-scripts lint jest"
+    "test": "run-scripts lint test:jest",
+    "test:jest": "cross-env CI=true jest"
   },
   "// dependency notes": [
     "@react-native-community/cli (transitive dependency from react-native-init-func)",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "cross-env CI=true seems to be needed to get the same results with",
       "some emoji symbols on both macOS workstation and GitHub Workflow"
     ],
-    "test": "npm run lint && cross-env CI=true jest"
+    "test": "run-scripts lint jest"
   },
   "// dependency notes": [
     "@react-native-community/cli (transitive dependency from react-native-init-func)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,6 +1514,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+async@^0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
 async@^2.4.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -5923,6 +5928,13 @@ run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
+
+run-scripts@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/run-scripts/-/run-scripts-0.4.0.tgz#930cfd79cfbdf2c5958ad2c210e0c72047bc2faa"
+  integrity sha1-kwz9ec+98sWVitLCEODHIEe8L6o=
+  dependencies:
+    async "^0.9.0"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
general rationale:

- cleaner than "npm run ... && npm run ..."
- seems to be much lighter weight than `npm-run-all`

This should help simplify the package scripts entries needed to use eslint and
Prettier on multiple types of files as proposed in PR #81.