### PR TITLE
use nested ternaries in tests, with recommended Prettier lint settings

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,5 +21,3 @@ rules:
       singleQuote: true
       spaceBeforeFunctionParen: true
       trailingComma: none
-  # TODO resolve ignored "Standard JS" rule:
-  curly: 0

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,9 @@
 parserOptions:
   ecmaVersion: 9
 
-extends: standard
+extends:
+  - standard
+  - plugin:prettier/recommended
 
 plugins:
   - prettier

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
       "- Prettier is used alone for the markup (*.md, *.json, *.yml) files",
       "- Prettier `--end-of-line=auto` option is needed for CI on Windows.",
       "- eslint-config-standard is used together with some eslint plugins",
-      "  to check conformance to 'Standard JS' rules, with a very limited",
-      "  number of exceptions at this point."
+      "  to check conformance to 'Standard JS' *coding* rules,",
+      "  using plugin:prettier/recommended to avoid conflicts in the formatting"
     ],
     "lint": "run-scripts lint:eslint lint:markup",
     "lint:markup": "prettier --check --end-of-line=auto ./**/*.md ./**/*.json ./**/*.yml",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "eslint": "^7.16.0",
+    "eslint-config-prettier": "^7.1.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -38,16 +38,11 @@ jest.mock('prompts', () => args => {
 
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
-  if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-  } else {
-    return Promise.resolve()
-  }
+  return cmd === 'git'
+    ? args[1] === 'user.email'
+        ? Promise.resolve({ stdout: 'alice@example.com' })
+        : Promise.resolve({ stdout: 'Alice' })
+    : Promise.resolve()
 })
 
 jest.mock('create-react-native-module', () => o => {

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -40,8 +40,8 @@ jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   return cmd === 'git'
     ? args[1] === 'user.email'
-        ? Promise.resolve({ stdout: 'alice@example.com' })
-        : Promise.resolve({ stdout: 'Alice' })
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
     : Promise.resolve()
 })
 

--- a/tests/no-example/no-example-module-all.test.js
+++ b/tests/no-example/no-example-module-all.test.js
@@ -44,8 +44,8 @@ jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   return cmd === 'git'
     ? args[1] === 'user.email'
-        ? Promise.resolve({ stdout: 'alice@example.com' })
-        : Promise.resolve({ stdout: 'Alice' })
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
     : Promise.resolve()
 })
 

--- a/tests/no-example/no-example-module-all.test.js
+++ b/tests/no-example/no-example-module-all.test.js
@@ -42,16 +42,11 @@ jest.mock('prompts', () => args => {
 
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
-  if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-  } else {
-    return Promise.resolve()
-  }
+  return cmd === 'git'
+    ? args[1] === 'user.email'
+        ? Promise.resolve({ stdout: 'alice@example.com' })
+        : Promise.resolve({ stdout: 'Alice' })
+    : Promise.resolve()
 })
 
 jest.mock('create-react-native-module', () => o => {

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -36,16 +36,11 @@ jest.mock('prompts', () => args => {
 
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
-  if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-  } else {
-    return Promise.resolve()
-  }
+  return cmd === 'git'
+    ? args[1] === 'user.email'
+        ? Promise.resolve({ stdout: 'alice@example.com' })
+        : Promise.resolve({ stdout: 'Alice' })
+    : Promise.resolve()
 })
 
 jest.mock('create-react-native-module', () => o => {

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -38,8 +38,8 @@ jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   return cmd === 'git'
     ? args[1] === 'user.email'
-        ? Promise.resolve({ stdout: 'alice@example.com' })
-        : Promise.resolve({ stdout: 'Alice' })
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
     : Promise.resolve()
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2720,6 +2720,11 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz#5402eb559aa94b894effd6bddfa0b1ca051c858f"
+  integrity sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==
+
 eslint-config-standard@^16.0.2:
   version "16.0.2"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz#71e91727ac7a203782d0a5ca4d1c462d14e234f6"


### PR DESCRIPTION
and remove the `curly` "Standard JS" exception from `eslintrc.yml`

The drawback is that some "Standard JS" indentation rules need to be turned off to avoid a conflict between "Standard JS" and Prettier(X).

It is *highly* desired by @brodybits to find a way to resolve the conflict between "Standard JS" and prettierx someday in the future.