### PR TITLE
remove "Standard JS" exception using ternary in tests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,5 +19,3 @@ rules:
       singleQuote: true
       spaceBeforeFunctionParen: true
       trailingComma: none
-  # TODO resolve ignored "Standard JS" rule:
-  curly: 0

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
       "- Prettier is used alone for the markup (*.md, *.json, *.yml) files",
       "- Prettier `--end-of-line=auto` option is needed for CI on Windows.",
       "- eslint-config-standard is used together with some eslint plugins",
-      "  to check conformance to 'Standard JS' rules, with a very limited",
-      "  number of exceptions at this point."
+      "  to check conformance to 'Standard JS' rules, now with no exceptions."
     ],
     "lint": "run-scripts lint:eslint lint:markup",
     "lint:markup": "prettier --check --end-of-line=auto ./**/*.md ./**/*.json ./**/*.yml",

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -39,12 +39,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -39,13 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return (args[1] === 'user.email')
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -39,7 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/init-with-example/init-with-example-with-log.test.js
+++ b/tests/init-with-example/init-with-example-with-log.test.js
@@ -39,7 +39,7 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    return (args[1] === 'user.email')
+    return args[1] === 'user.email'
       ? Promise.resolve({ stdout: 'alice@example.com' })
       : Promise.resolve({ stdout: 'Alice' })
   } else {

--- a/tests/no-example/no-example-module-all.test.js
+++ b/tests/no-example/no-example-module-all.test.js
@@ -43,7 +43,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/no-example/no-example-module-all.test.js
+++ b/tests/no-example/no-example-module-all.test.js
@@ -43,13 +43,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/no-example/no-example-module-all.test.js
+++ b/tests/no-example/no-example-module-all.test.js
@@ -43,12 +43,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -39,12 +39,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -39,7 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/tvos/view-with-example/tvos-view-with-example.test.js
+++ b/tests/tvos/view-with-example/tvos-view-with-example.test.js
@@ -39,13 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -39,12 +39,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -39,7 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/tvos/with-example/tvos-with-example.test.js
+++ b/tests/tvos/with-example/tvos-with-example.test.js
@@ -39,13 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -37,12 +37,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -37,7 +37,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/view/no-example/init-view-no-example-with-log.test.js
+++ b/tests/view/no-example/init-view-no-example-with-log.test.js
@@ -37,13 +37,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -39,12 +39,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -39,7 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/view/with-example/init-view-with-example-with-log.test.js
+++ b/tests/view/with-example/init-view-with-example-with-log.test.js
@@ -39,13 +39,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -37,12 +37,11 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email')
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    else
+    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
       return Promise.resolve({
         stdout: 'Alice'
       })
+    }
   } else {
     return Promise.resolve()
   }

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -37,7 +37,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') { return Promise.resolve({ stdout: 'alice@example.com' }) } else {
+    if (args[1] === 'user.email') {
+      return Promise.resolve({ stdout: 'alice@example.com' })
+    } else {
       return Promise.resolve({
         stdout: 'Alice'
       })

--- a/tests/with-apple-networking/with-apple-networking.test.js
+++ b/tests/with-apple-networking/with-apple-networking.test.js
@@ -37,13 +37,9 @@ jest.mock('prompts', () => args => {
 jest.mock('execa', () => (cmd, args, opts) => {
   mockCallSnapshot.push({ execa: [cmd, args, opts] })
   if (cmd === 'git') {
-    if (args[1] === 'user.email') {
-      return Promise.resolve({ stdout: 'alice@example.com' })
-    } else {
-      return Promise.resolve({
-        stdout: 'Alice'
-      })
-    }
+    return args[1] === 'user.email'
+      ? Promise.resolve({ stdout: 'alice@example.com' })
+      : Promise.resolve({ stdout: 'Alice' })
   } else {
     return Promise.resolve()
   }


### PR DESCRIPTION
__updated__

(non-nested ternary expressions to avoid conflict between prettierx & "Standard JS")

This should now be 100% compliant with "Standard JS".

Supersedes PR #86 ~~which will be preserved to investigate an issue with `lint:fix` on macOS and possibly Linux~~.